### PR TITLE
refactor: use positive lookahead in RegExp

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ exports.escapePipesInTables = str => {
     let line = lines[i];
 
     if (/^\s*\|.*?\|\s*$/.test(line)) {
-      lines[i] = line.replace(/(?<!`)`((?:\\`|[^`])+)`(?!`)/g, m => {
+      lines[i] = line.replace(/(?:[^`])`((?:\\`|[^`])+)`(?!`)/g, m => {
         return m.replace(/\s*\|\s*/g, '\\|');
       });
     }


### PR DESCRIPTION
Since negative lookbehind is relatively new(which got accepted in ECMAScript in 2018) and only v8 and node.js behind v9 without a flag support it, it's more convenient and compatible to use positive lookahead instead.

ref: https://stackoverflow.com/questions/641407/javascript-negative-lookbehind-equivalent