### PR TITLE
chore: upgrade remarkable to ^2.0.0

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -8,7 +8,7 @@
 'use strict';
 
 const sections = require('sections');
-const Remarkable = require('remarkable');
+const { Remarkable } = require('remarkable');
 const prettify = require('pretty-remarkable');
 const utils = require('./utils');
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "pretty-remarkable": "^1.0.0",
-    "remarkable": "^1.7.1",
+    "remarkable": "^2.0.0",
     "sections": "^1.0.0",
     "through2": "^2.0.3"
   },


### PR DESCRIPTION
This PR pushes remarkable forward to the next major version, not only for this project, but it also paves the way to solve this issue as well.

https://github.com/jonschlinkert/markdown-toc/issues/156